### PR TITLE
Dockerfile: Add ca-certificates and openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
         libegl1-mesa \
         libsdl1.2-dev \
         locales \
+        openssh-client \
         openssl \
         python \
         python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     \
     apt-get install -y --no-install-recommends \
         build-essential \
+        ca-certificates \
         chrpath \
         cpio \
         debianutils \
@@ -31,6 +32,7 @@ RUN apt-get update && \
         libegl1-mesa \
         libsdl1.2-dev \
         locales \
+        openssl \
         python \
         python3 \
         socat \


### PR DESCRIPTION
Some packages need authentication to fetch correctly.

Avoid the following error:
certificate signed by unknown authority

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>