### PR TITLE
Dockerfile: Add liblz4-tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
         iputils-ping \
         less \
         libegl1-mesa \
+        liblz4-tool \
         libsdl1.2-dev \
         locales \
         openssh-client \


### PR DESCRIPTION
Yocto Project version >= 3.4 requires lz4 as essential host packages,
add liblz4-tool that it's supported for both 18.04 and 20.04 Ubuntu
versions.

Signed-off-by: Fabio Berton <fbberton@gmail.com>