### PR TITLE
Dockerfile: Add iproute2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && \
         \
         jq \
         curl \
+        iproute2 \
         libncurses-dev \
         git-lfs \
         nano \


### PR DESCRIPTION
As explained in [1], the iproute2 package is required when using QEMU to
boot images.

[1] - https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#qemu-image-enabling-tests

Signed-off-by: Fabio Berton <fbberton@gmail.com>